### PR TITLE
增加 Github 仓库链接 并允许折叠侧导航栏项目

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -6,6 +6,11 @@ title = "WitchGci"
 
 [output.html]
 no-section-label = true
+git-repository-url = "https://github.com/Moon-of-Noon/witchgci"
 
 [output.html.print]
 enable = false
+
+[output.html.fold]
+enable = true
+level = 10


### PR DESCRIPTION
<img width="316" height="119" alt="image" src="https://github.com/user-attachments/assets/bcf74fba-3afb-4d3c-8664-1bb5fa393a93" />

- 通过右侧箭头折叠章节

<img width="101" height="92" alt="image" src="https://github.com/user-attachments/assets/c41f3383-7e72-4fa6-b0f0-f6ef425ddf6b" />

- 仓库链接图标放置至页面右上角