### PR TITLE
为有层级的页面自动生成目录

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -29,7 +29,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      MDBOOK_VERSION: 0.4.44
+      MDBOOK_VERSION: 0.4.52
     steps:
       - uses: actions/checkout@v4
       - name: 启用缓存
@@ -40,6 +40,7 @@ jobs:
           rustup update
           cargo install --version ${MDBOOK_VERSION} mdbook
           cargo install --git https://github.com/HoiGe/book-summary.git --rev 8aae2527e0234d233cc9a1952cbcc011fb256e95 book-summary
+          cargo install --git https://github.com/HoiGe/mdbook-chapter-list.git --rev d3897798e03a97bb666de4aad0e82d77b1110fbd mdbook-chapter-list
       - name: 初始化 Page
         id: pages
         uses: actions/configure-pages@v5

--- a/book.toml
+++ b/book.toml
@@ -3,6 +3,7 @@ authors = ["Moon-of-Noon"]
 language = "zh-CN"
 src = ""
 title = "Witchgci"
+site-url = "/witchgci/"
 
 [output.html]
 no-section-label = true
@@ -14,3 +15,5 @@ enable = false
 [output.html.fold]
 enable = true
 level = 10
+
+[preprocessor.chapter-list]


### PR DESCRIPTION
## 修改

- 增加预处理器 [`mdbook-chapter-list`](https://github.com/HoiGe/mdbook-chapter-list)
- 更新 `mdbook` 至 0.4.52
- 测试 `site-url`

## 部署测试

[Action #2](https://github.com/HoiGe/witchgci/actions/runs/24172092979)

## 参考效果

![7456C2C3003C3EE02748C4C49B1E10BD](https://github.com/user-attachments/assets/58b396be-f786-46d1-aa28-de0b038089b8)


