### PR TITLE
更新依赖项:修复部署失败的问题

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -39,8 +39,8 @@ jobs:
           curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh
           rustup update
           cargo install --version ${MDBOOK_VERSION} mdbook
-          cargo install --git https://github.com/HoiGe/book-summary.git --rev 8aae2527e0234d233cc9a1952cbcc011fb256e95 book-summary
-          cargo install --git https://github.com/HoiGe/mdbook-chapter-list.git --rev d3897798e03a97bb666de4aad0e82d77b1110fbd mdbook-chapter-list
+          cargo install --git https://github.com/HoiGe/book-summary.git --rev 18d93b00e9f740279146494658f03c5447cc5555 book-summary
+          cargo install --git https://github.com/HoiGe/mdbook-chapter-list.git --rev e0affbe16c3fe570b94e2f72b3b9e94c5ac1f8fb mdbook-chapter-list
       - name: 初始化 Page
         id: pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
## 更新
- 忽略 Markdown 文件夹

## 待解决问题
- 有同名文件夹时会报错的BUG