### PR TITLE
fix: 文件夹自动生成目录会在根目录创建

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       MDBOOK_VERSION: 0.4.52
       BOOK_SUMMARY_REV: 4aeb6b4dbde38abc6a616f53d3f14056959a2a10
-      CHAPTER_LIST_REV: deeffe04edde297e163c91d63eeffbb8298ba65d
+      CHAPTER_LIST_REV: b408e11083c9f0fcaba2d4f32a1429f15784d2ba
     steps:
       - name: 检出仓库
         uses: actions/checkout@v6

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -1,67 +1,71 @@
-# Sample workflow for building and deploying a mdBook site to GitHub Pages
-#
-# To get started with mdBook see: https://rust-lang.github.io/mdBook/index.html
-#
-name: 部署内容到 Github Pages
+name: 部署内容到 GitHub Pages
 
 on:
-  # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: "pages"
+  group: pages
   cancel-in-progress: false
 
 jobs:
-  # Build job
   build:
+    name: 构建 mdBook
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       MDBOOK_VERSION: 0.4.52
+      BOOK_SUMMARY_REV: 4aeb6b4dbde38abc6a616f53d3f14056959a2a10
+      CHAPTER_LIST_REV: b160a53756f3a61e7c243460daddbcbfa8fdd351
     steps:
-      - uses: actions/checkout@v4
-      - name: 启用缓存
+      - name: 检出仓库
+        uses: actions/checkout@v6
+
+      - name: 安装 Rust 工具链
+        uses: dtolnay/rust-toolchain@1.89.0
+
+      - name: 启用 Cargo 缓存
         uses: Swatinem/rust-cache@v2
-      - name: 安装 mdBook
+
+      - name: 安装 mdBook 和预处理工具
         run: |
-          curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh
-          rustup update
-          cargo install --version ${MDBOOK_VERSION} mdbook
-          cargo install --git https://github.com/HoiGe/book-summary.git --rev 18d93b00e9f740279146494658f03c5447cc5555 book-summary
-          cargo install --git https://github.com/HoiGe/mdbook-chapter-list.git --rev e0affbe16c3fe570b94e2f72b3b9e94c5ac1f8fb mdbook-chapter-list
-      - name: 初始化 Page
-        id: pages
+          set -euo pipefail
+          cargo install --locked --version "${MDBOOK_VERSION}" mdbook
+          cargo install --locked --git https://github.com/HoiGe/book-summary.git --rev "${BOOK_SUMMARY_REV}" book-summary
+          cargo install --locked --git https://github.com/HoiGe/mdbook-chapter-list.git --rev "${CHAPTER_LIST_REV}" mdbook-chapter-list
+
+      - name: 配置 GitHub Pages
         uses: actions/configure-pages@v5
-      - name: 自动生成目录
+
+      - name: 生成目录
         run: |
-          ~/.cargo/bin/book-summary -y -n ./
-          awk 'NR==2{print; print "- [前言](README.md)"; next}1' SUMMARY.md > tmp && mv tmp SUMMARY.md
-      - name: 生成页面
-        run: ~/.cargo/bin/mdbook build
-      - name: 上传资源
-        uses: actions/upload-pages-artifact@v3
+          set -euo pipefail
+          book-summary -y -n ./
+          awk 'NR==2{print; print "- [前言](README.md)"; next}1' SUMMARY.md > SUMMARY.tmp
+          mv SUMMARY.tmp SUMMARY.md
+
+      - name: 构建页面
+        run: mdbook build
+
+      - name: 上传页面资源
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./book
 
-  # Deployment job
   deploy:
+    name: 部署 GitHub Pages
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: build
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
     steps:
       - name: 部署到 GitHub Pages
         id: deployment

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       MDBOOK_VERSION: 0.4.52
       BOOK_SUMMARY_REV: 4aeb6b4dbde38abc6a616f53d3f14056959a2a10
-      CHAPTER_LIST_REV: b160a53756f3a61e7c243460daddbcbfa8fdd351
+      CHAPTER_LIST_REV: deeffe04edde297e163c91d63eeffbb8298ba65d
     steps:
       - name: 检出仓库
         uses: actions/checkout@v6


### PR DESCRIPTION
## 更新

- 空文件夹目录页将根据文件结构进行生成 #43 
- 在 `book.toml` 中忽略页面 使其不生成目录
- 支持中文数字排序识别「一」「壹」 
- 现在不匹配本作格式的数字标题会自动按大小排序
- 部署脚本现在只会安装固定版本的工具链 `rust-toolchain@1.89.0`
- 更新部署脚本依赖项
  - actions/checkout@v6
  - actions/upload-pages-artifact@v5
- 优化部署脚本可读性

 ### 使用示例

```diff
[preprocessor.chapter-list]
+ ignored-files = ["draft.md", "internal/notes.md"]
```